### PR TITLE
Migration for 4th AGM slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ CI **does not** generate migrations; it only plans and deploys committed ones.
 ## Database Changelog
 | Version | Comments/Updates |
 | - | - |
+| `v5.2.1` | Added optional `agm4ID` in the `Franchise` table and it's respective `AGM4` relation in the `User` table |
+| `5.2.0` | Added `banner` column to the `User` table |
 | `v5.1.0` | Added `RECRUIT` Tier to ENUM's, Updated Season Defaults to `9`, Added `MANUAL_REVIEW` to playerstatus ENUM |
 | `s9_baseline` | Baseline the db before implementing s9 changes. |
 | `4.0.5` | Added `group` column to the `Matches` table |

--- a/_Franchise.ts
+++ b/_Franchise.ts
@@ -59,35 +59,35 @@ export class Franchise {
         if (id) return await prisma.franchise.findFirst({
             where: { id: id },
             include: {
-                GM: { include: { Accounts: true } }, AGM1: { include: { Accounts: true } }, AGM2: { include: { Accounts: true } }, AGM3: { include: { Accounts: true } }, Brand: true, Teams: true
+                GM: { include: { Accounts: true } }, AGM1: { include: { Accounts: true } }, AGM2: { include: { Accounts: true } }, AGM3: { include: { Accounts: true } }, AGM4: { include: { Accounts: true } }, Brand: true, Teams: true
             }
         });
 
         if (name) return await prisma.franchise.findFirst({
             where: { name: name },
             include: {
-                GM: { include: { Accounts: true } }, AGM1: { include: { Accounts: true } }, AGM2: { include: { Accounts: true } }, AGM3: { include: { Accounts: true } }, Brand: true, Teams: true
+                GM: { include: { Accounts: true } }, AGM1: { include: { Accounts: true } }, AGM2: { include: { Accounts: true } }, AGM3: { include: { Accounts: true } }, AGM4: { include: { Accounts: true } }, Brand: true, Teams: true
             }
         });
 
         if (slug) return await prisma.franchise.findFirst({
             where: { slug: slug },
             include: {
-                GM: { include: { Accounts: true } }, AGM1: { include: { Accounts: true } }, AGM2: { include: { Accounts: true } }, AGM3: { include: { Accounts: true } }, Brand: true, Teams: true
+                GM: { include: { Accounts: true } }, AGM1: { include: { Accounts: true } }, AGM2: { include: { Accounts: true } }, AGM3: { include: { Accounts: true } }, AGM4: { include: { Accounts: true } }, Brand: true, Teams: true
             }
         });
 
         if (teamID) return await prisma.franchise.findFirst({
             where: { Teams: { some: { id: teamID } } },
             include: {
-                GM: { include: { Accounts: true } }, AGM1: { include: { Accounts: true } }, AGM2: { include: { Accounts: true } }, AGM3: { include: { Accounts: true } }, Brand: true, Teams: true
+                GM: { include: { Accounts: true } }, AGM1: { include: { Accounts: true } }, AGM2: { include: { Accounts: true } }, AGM3: { include: { Accounts: true } }, AGM4: { include: { Accounts: true } }, Brand: true, Teams: true
             }
         });
 
         if (teamName) return await prisma.franchise.findFirst({
             where: { Teams: { some: { name: teamName } } },
             include: {
-                GM: { include: { Accounts: true } }, AGM1: { include: { Accounts: true } }, AGM2: { include: { Accounts: true } }, AGM3: { include: { Accounts: true } }, Brand: true, Teams: true
+                GM: { include: { Accounts: true } }, AGM1: { include: { Accounts: true } }, AGM2: { include: { Accounts: true } }, AGM3: { include: { Accounts: true } }, AGM4: { include: { Accounts: true } }, Brand: true, Teams: true
             }
         });
     };

--- a/_Player.ts
+++ b/_Player.ts
@@ -134,6 +134,7 @@ export class Player {
                             AGM1: { include: { Accounts: true } },
                             AGM2: { include: { Accounts: true } },
                             AGM3: { include: { Accounts: true } },
+                            AGM4: { include: { Accounts: true } }, 
                         }
                     }
                 }

--- a/migrations/20251105012449_v5_2_1/migration.sql
+++ b/migrations/20251105012449_v5_2_1/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[agm4ID]` on the table `Franchise` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE `Franchise` ADD COLUMN `agm4ID` VARCHAR(191) NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `Franchise_agm4ID_key` ON `Franchise`(`agm4ID`);
+
+-- AddForeignKey
+ALTER TABLE `Franchise` ADD CONSTRAINT `Franchise_AGM4` FOREIGN KEY (`agm4ID`) REFERENCES `User`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/schema.prisma
+++ b/schema.prisma
@@ -58,6 +58,7 @@ model User {
   AGM1                 Franchise?    @relation("AGM1")
   AGM2                 Franchise?    @relation("AGM2")
   AGM3                 Franchise?    @relation("AGM3")
+  AGM4                 Franchise?    @relation("AGM4")
   GM                   Franchise?    @relation("GM")
   ModLogs              ModLogs[]     @relation("ModHistory")
   PlayerStats          PlayerStats[] @relation("UserPlayerStats")
@@ -133,11 +134,13 @@ model Franchise {
   agm1ID                String?         @unique
   agm2ID                String?         @unique
   agm3ID                String?         @unique
+  agm4ID                String?         @unique
   transactionsChannelID String?
   DraftPicks            Draft[]
   AGM1                  User?           @relation("AGM1", fields: [agm1ID], references: [id], map: "Franchise_AGM1")
   AGM2                  User?           @relation("AGM2", fields: [agm2ID], references: [id], map: "Franchise_AGM2")
   AGM3                  User?           @relation("AGM3", fields: [agm3ID], references: [id], map: "Franchise_AGM3")
+  AGM4                  User?           @relation("AGM4", fields: [agm4ID], references: [id], map: "Franchise_AGM4")
   GM                    User?           @relation("GM", fields: [gmID], references: [id], map: "Franchise_GM")
   Brand                 FranchiseBrand?
   Teams                 Teams[]


### PR DESCRIPTION
## Summary
Added 4th AGM slot.

## DB
- [x] Migrations included (if schema changed)

## Release
Release Version (optional): v5.2.1
<!-- Example: v1.9.0  (must be > last tag). Leave blank to auto-bump. -->
