### PR TITLE
v6.0.0 - Add Pickem tables and Transaction table

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ CI **does not** generate migrations; it only plans and deploys committed ones.
 ## Database Changelog
 | Version | Comments/Updates |
 | - | - |
+| `v6.0.0` | Added Pickem tables (`PickemMatchPick`, `PickemAdvancePick`, `PickemGroup`, `PickemGroupMember`) and the `Transaction` table with the `TransactionType` enum, all with relevant relations to `User`, `Teams`, `Matches` & `Franchise` <br> Added `PICKEM_ADVANCE_LOCK`, `PICKEM_PREVIEW` & `PICKEM_ENABLED` control panel settings <br> Added `ACTIVATE` & `REBRAND` values to the `TransactionType` enum <br> Updated season defaults from `9` to `10` on the `Matches`, `Games` & `ModLogs` tables |
 | `v5.2.1` | Added optional `agm4ID` in the `Franchise` table and it's respective `AGM4` relation in the `User` table |
 | `5.2.0` | Added `banner` column to the `User` table |
 | `v5.1.0` | Added `RECRUIT` Tier to ENUM's, Updated Season Defaults to `9`, Added `MANUAL_REVIEW` to playerstatus ENUM |

--- a/_Transaction.ts
+++ b/_Transaction.ts
@@ -1,5 +1,6 @@
-import { ContractStatus, LeagueStatus, PrismaClient, Tier } from '@prisma/client';
+import { ContractStatus, LeagueStatus, PrismaClient, Tier, TransactionType } from '@prisma/client';
 import { Player } from './_Player';
+import { ControlPanel } from './_ControlPanel';
 
 const prisma = new PrismaClient();
 
@@ -210,6 +211,32 @@ export class Transaction {
         return await prisma.matches.update({
             where: { matchID: matchID },
             data: { dateScheduled: newDate }
+        });
+    };
+
+    /** Record a transaction in the transactions history table. The current season is
+     * resolved internally, so callers only supply the transaction-specific columns. */
+    static async log(
+        options: {
+            type: TransactionType,
+            userID?: string | null,
+            teamID?: number | null,
+            franchiseID?: number | null,
+            tier?: Tier | null,
+            details?: object | null,
+        }
+    ) {
+        const season = await ControlPanel.getSeason();
+        return await prisma.transaction.create({
+            data: {
+                type: options.type,
+                season: season,
+                userID: options.userID ?? null,
+                team: options.teamID ?? null,
+                franchise: options.franchiseID ?? null,
+                tier: options.tier ?? null,
+                details: options.details ? JSON.stringify(options.details) : null,
+            }
         });
     };
 };

--- a/enums/_controlpanel.ts
+++ b/enums/_controlpanel.ts
@@ -27,4 +27,8 @@ export enum ControlPanelID {
     MAP_POOL                        = 21,
 
     WELCOME_MESSAGE                 = 22,
+
+    PICKEM_ADVANCE_LOCK             = 43,
+    PICKEM_PREVIEW                  = 44,
+    PICKEM_ENABLED                  = 45,
 }

--- a/migrations/20260630194143_v6_0_0/migration.sql
+++ b/migrations/20260630194143_v6_0_0/migration.sql
@@ -1,0 +1,120 @@
+-- AlterTable
+ALTER TABLE `Matches` MODIFY `season` INTEGER NOT NULL DEFAULT 10;
+
+-- AlterTable
+ALTER TABLE `Games` MODIFY `season` INTEGER NOT NULL DEFAULT 10;
+
+-- AlterTable
+ALTER TABLE `ModLogs` MODIFY `season` INTEGER NOT NULL DEFAULT 10;
+
+-- CreateTable
+CREATE TABLE `PickemMatchPick` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `userID` VARCHAR(191) NOT NULL,
+    `matchID` INTEGER NOT NULL,
+    `predictedHomeScore` INTEGER NOT NULL,
+    `predictedAwayScore` INTEGER NOT NULL,
+
+    UNIQUE INDEX `PickemMatchPick_id_key`(`id`),
+    INDEX `PickemMatchPick_userID_fkey`(`userID`),
+    INDEX `PickemMatchPick_matchID_fkey`(`matchID`),
+    UNIQUE INDEX `PickemMatchPick_userID_matchID_key`(`userID`, `matchID`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `PickemAdvancePick` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `userID` VARCHAR(191) NOT NULL,
+    `season` INTEGER NOT NULL,
+    `tier` ENUM('RECRUIT', 'PROSPECT', 'APPRENTICE', 'EXPERT', 'MYTHIC', 'MIXED') NOT NULL,
+    `predictedTeam` INTEGER NOT NULL,
+    `predictedSeed` INTEGER NOT NULL,
+
+    UNIQUE INDEX `PickemAdvancePick_id_key`(`id`),
+    INDEX `PickemAdvancePick_userID_fkey`(`userID`),
+    INDEX `PickemAdvancePick_predictedTeam_fkey`(`predictedTeam`),
+    UNIQUE INDEX `PickemAdvancePick_userID_season_tier_predictedTeam_key`(`userID`, `season`, `tier`, `predictedTeam`),
+    UNIQUE INDEX `PickemAdvancePick_userID_season_tier_predictedSeed_key`(`userID`, `season`, `tier`, `predictedSeed`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `PickemGroup` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(191) NOT NULL,
+    `image` VARCHAR(191) NOT NULL,
+    `season` INTEGER NOT NULL,
+    `ownerID` VARCHAR(191) NOT NULL,
+    `joinCode` VARCHAR(191) NOT NULL,
+
+    UNIQUE INDEX `PickemGroup_id_key`(`id`),
+    UNIQUE INDEX `PickemGroup_joinCode_key`(`joinCode`),
+    INDEX `PickemGroup_ownerID_fkey`(`ownerID`),
+    INDEX `PickemGroup_season_idx`(`season`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `PickemGroupMember` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `groupID` INTEGER NOT NULL,
+    `userID` VARCHAR(191) NOT NULL,
+
+    UNIQUE INDEX `PickemGroupMember_id_key`(`id`),
+    INDEX `PickemGroupMember_groupID_fkey`(`groupID`),
+    INDEX `PickemGroupMember_userID_fkey`(`userID`),
+    UNIQUE INDEX `PickemGroupMember_groupID_userID_key`(`groupID`, `userID`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Transaction` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `type` ENUM('ACTIVATE', 'CAPTAIN', 'CUT', 'EXPIRE', 'IR', 'REBRAND', 'RENEW', 'RESCHEDULE', 'RETIRE', 'SCHEDULE_PLAYOFF', 'SIGN', 'SUB', 'TRADE', 'UNSUB', 'UPDATE_TIER') NOT NULL,
+    `season` INTEGER NOT NULL,
+    `date` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `userID` VARCHAR(191) NULL,
+    `team` INTEGER NULL,
+    `franchise` INTEGER NULL,
+    `tier` ENUM('RECRUIT', 'PROSPECT', 'APPRENTICE', 'EXPERT', 'MYTHIC', 'MIXED') NULL,
+    `details` TEXT NULL,
+
+    UNIQUE INDEX `Transaction_id_key`(`id`),
+    INDEX `Transaction_userID_fkey`(`userID`),
+    INDEX `Transaction_team_fkey`(`team`),
+    INDEX `Transaction_franchise_fkey`(`franchise`),
+    INDEX `Transaction_season_idx`(`season`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `PickemMatchPick` ADD CONSTRAINT `PickemMatchPick_userID_fkey` FOREIGN KEY (`userID`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `PickemMatchPick` ADD CONSTRAINT `PickemMatchPick_matchID_fkey` FOREIGN KEY (`matchID`) REFERENCES `Matches`(`matchID`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `PickemAdvancePick` ADD CONSTRAINT `PickemAdvancePick_userID_fkey` FOREIGN KEY (`userID`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `PickemAdvancePick` ADD CONSTRAINT `PickemAdvancePick_predictedTeam_fkey` FOREIGN KEY (`predictedTeam`) REFERENCES `Teams`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `PickemGroup` ADD CONSTRAINT `PickemGroup_ownerID_fkey` FOREIGN KEY (`ownerID`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `PickemGroupMember` ADD CONSTRAINT `PickemGroupMember_groupID_fkey` FOREIGN KEY (`groupID`) REFERENCES `PickemGroup`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `PickemGroupMember` ADD CONSTRAINT `PickemGroupMember_userID_fkey` FOREIGN KEY (`userID`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Transaction` ADD CONSTRAINT `Transaction_userID_fkey` FOREIGN KEY (`userID`) REFERENCES `User`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Transaction` ADD CONSTRAINT `Transaction_team_fkey` FOREIGN KEY (`team`) REFERENCES `Teams`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Transaction` ADD CONSTRAINT `Transaction_franchise_fkey` FOREIGN KEY (`franchise`) REFERENCES `Franchise`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/schema.prisma
+++ b/schema.prisma
@@ -41,35 +41,40 @@ model Session {
 }
 
 model User {
-  id                   String        @id @unique @default(cuid())
-  name                 String?
-  team                 Int?
-  primaryRiotAccountID String?       @unique
-  email                String?       @unique
-  emailVerified        DateTime?
-  image                String?
-  banner               String?
-  roles                String        @default("0x0")
-  flags                String        @default("0x0")
-  createdAt            DateTime      @default(now())
-  Accolades            Accolades[]
-  Accounts             Account[]     @relation("Accounts")
-  Draft                Draft[]       @relation("PlayerDraftPick")
-  AGM1                 Franchise?    @relation("AGM1")
-  AGM2                 Franchise?    @relation("AGM2")
-  AGM3                 Franchise?    @relation("AGM3")
-  AGM4                 Franchise?    @relation("AGM4")
-  GM                   Franchise?    @relation("GM")
-  ModLogs              ModLogs[]     @relation("ModHistory")
-  PlayerStats          PlayerStats[] @relation("UserPlayerStats")
-  Records              Records[]
-  sessions             Session[]
-  Status               Status?       @relation("PlayerStatus")
-  Substitute           Substitute[]  @relation("Sub")
-  SubbedOut            Substitute[]  @relation("Subbed")
-  Captain              Teams?        @relation("Captain")
-  PrimaryRiotAccount   Account?      @relation("PrimaryRiotAccount", fields: [primaryRiotAccountID], references: [providerAccountId])
-  Team                 Teams?        @relation(fields: [team], references: [id])
+  id                     String              @id @unique @default(cuid())
+  name                   String?
+  team                   Int?
+  primaryRiotAccountID   String?             @unique
+  email                  String?             @unique
+  emailVerified          DateTime?
+  image                  String?
+  banner                 String?
+  roles                  String              @default("0x0")
+  flags                  String              @default("0x0")
+  createdAt              DateTime            @default(now())
+  Accolades              Accolades[]
+  Accounts               Account[]           @relation("Accounts")
+  Draft                  Draft[]             @relation("PlayerDraftPick")
+  AGM1                   Franchise?          @relation("AGM1")
+  AGM2                   Franchise?          @relation("AGM2")
+  AGM3                   Franchise?          @relation("AGM3")
+  AGM4                   Franchise?          @relation("AGM4")
+  GM                     Franchise?          @relation("GM")
+  ModLogs                ModLogs[]           @relation("ModHistory")
+  PlayerStats            PlayerStats[]       @relation("UserPlayerStats")
+  Records                Records[]
+  sessions               Session[]
+  Status                 Status?             @relation("PlayerStatus")
+  Substitute             Substitute[]        @relation("Sub")
+  SubbedOut              Substitute[]        @relation("Subbed")
+  Captain                Teams?              @relation("Captain")
+  PrimaryRiotAccount     Account?            @relation("PrimaryRiotAccount", fields: [primaryRiotAccountID], references: [providerAccountId])
+  Team                   Teams?              @relation(fields: [team], references: [id])
+  PickemMatchPicks       PickemMatchPick[]   @relation("UserPickemMatchPicks")
+  PickemAdvancePicks     PickemAdvancePick[] @relation("UserPickemAdvancePicks")
+  PickemGroupsOwned      PickemGroup[]       @relation("UserPickemGroupsOwned")
+  PickemGroupMemberships PickemGroupMember[] @relation("UserPickemGroupMemberships")
+  Transactions           Transaction[]       @relation("PlayerTransactions")
 
   @@index([team], map: "User_team_fkey")
 }
@@ -104,22 +109,24 @@ model Records {
 }
 
 model Teams {
-  id                 Int           @id @unique @default(autoincrement())
+  id                 Int                 @id @unique @default(autoincrement())
   name               String
   tier               Tier
-  active             Boolean       @default(true)
+  active             Boolean             @default(true)
   franchise          Int
-  captain            String?       @unique
+  captain            String?             @unique
   midSeasonPlacement Int?
-  GamesWon           Games[]       @relation("GamesWon")
+  GamesWon           Games[]             @relation("GamesWon")
   MapBans            MapBans[]
-  AwayMatches        Matches[]     @relation("AwayMatches")
-  HomeMatches        Matches[]     @relation("HomeMatches")
+  AwayMatches        Matches[]           @relation("AwayMatches")
+  HomeMatches        Matches[]           @relation("HomeMatches")
   PlayerStats        PlayerStats[]
   Substitutes        Substitute[]
-  Captain            User?         @relation("Captain", fields: [captain], references: [id])
-  Franchise          Franchise     @relation(fields: [franchise], references: [id])
+  Captain            User?               @relation("Captain", fields: [captain], references: [id])
+  Franchise          Franchise           @relation(fields: [franchise], references: [id])
   Roster             User[]
+  PickemAdvancePicks PickemAdvancePick[] @relation("PickemAdvancePicks")
+  Transactions       Transaction[]       @relation("TeamTransactions")
 
   @@index([franchise], map: "Teams_franchise_fkey")
 }
@@ -144,6 +151,7 @@ model Franchise {
   GM                    User?           @relation("GM", fields: [gmID], references: [id], map: "Franchise_GM")
   Brand                 FranchiseBrand?
   Teams                 Teams[]
+  Transactions          Transaction[]   @relation("FranchiseTransactions")
 }
 
 model FranchiseBrand {
@@ -196,20 +204,21 @@ model Substitute {
 }
 
 model Matches {
-  matchID       Int          @id @unique @default(autoincrement())
-  tier          Tier
-  matchType     MatchType
-  dateScheduled DateTime
-  home          Int?
-  away          Int?
-  matchDay      Int?
-  season        Int          @default(9)
-  group         Int?
-  Games         Games[]
-  MapBans       MapBans[]
-  Away          Teams?       @relation("AwayMatches", fields: [away], references: [id], map: "Away_Team")
-  Home          Teams?       @relation("HomeMatches", fields: [home], references: [id], map: "Home_Team")
-  Substitutes   Substitute[]
+  matchID          Int               @id @unique @default(autoincrement())
+  tier             Tier
+  matchType        MatchType
+  dateScheduled    DateTime
+  home             Int?
+  away             Int?
+  matchDay         Int?
+  season           Int               @default(10)
+  group            Int?
+  Games            Games[]
+  MapBans          MapBans[]
+  Away             Teams?            @relation("AwayMatches", fields: [away], references: [id], map: "Away_Team")
+  Home             Teams?            @relation("HomeMatches", fields: [home], references: [id], map: "Home_Team")
+  Substitutes      Substitute[]
+  PickemMatchPicks PickemMatchPick[]
 
   @@index([away], map: "Away_Team")
   @@index([home], map: "Home_Team")
@@ -235,7 +244,7 @@ model Games {
   // Forfeits will submit a datetime as the unique ID, and fill in the gameType as FORFEIT
   // Invalid matches include matches that do NOT have ONLY VDC players in the database or out of tier matches
   matchID       Int?
-  season        Int           @default(9)
+  season        Int           @default(10)
   tier          Tier
   gameType      GameType
   datePlayed    DateTime
@@ -319,7 +328,7 @@ model ModLogs {
   id        Int        @id @unique @default(autoincrement())
   discordID String // this is the userID of the player who is being logged (Discord ID)
   modID     String // this is the userID of the mod who is logging (VDC ID)
-  season    Int        @default(9)
+  season    Int        @default(10)
   date      DateTime   @default(now())
   type      ModLogType
   message   String     @db.Text
@@ -352,6 +361,82 @@ model ApiAccess {
   active           Boolean @default(true)
   rateLimit        Int     @default(30) // Default to 30 requests/min
   allowedEndpoints String  @db.LongText // List of allowed endpoints
+}
+
+model PickemMatchPick {
+  id                 Int     @id @unique @default(autoincrement())
+  userID             String
+  matchID            Int
+  predictedHomeScore Int
+  predictedAwayScore Int
+  Player             User    @relation("UserPickemMatchPicks", fields: [userID], references: [id], onDelete: Cascade)
+  Match              Matches @relation(fields: [matchID], references: [matchID])
+
+  @@unique([userID, matchID])
+  @@index([userID], map: "PickemMatchPick_userID_fkey")
+  @@index([matchID], map: "PickemMatchPick_matchID_fkey")
+}
+
+model PickemAdvancePick {
+  id            Int    @id @unique @default(autoincrement())
+  userID        String
+  season        Int
+  tier          Tier
+  predictedTeam Int
+  predictedSeed Int // predicted seed position 1..N
+  Player        User   @relation("UserPickemAdvancePicks", fields: [userID], references: [id], onDelete: Cascade)
+  Team          Teams  @relation("PickemAdvancePicks", fields: [predictedTeam], references: [id])
+
+  @@unique([userID, season, tier, predictedTeam])
+  @@unique([userID, season, tier, predictedSeed])
+  @@index([userID], map: "PickemAdvancePick_userID_fkey")
+  @@index([predictedTeam], map: "PickemAdvancePick_predictedTeam_fkey")
+}
+
+model PickemGroup {
+  id       Int                 @id @unique @default(autoincrement())
+  name     String
+  image    String // agent UUID chosen by the owner; builds AGENTURL(image)
+  season   Int // a group is tied to one season (set by createGroup to the current season)
+  ownerID  String
+  joinCode String              @unique @default(cuid())
+  Owner    User                @relation("UserPickemGroupsOwned", fields: [ownerID], references: [id])
+  Members  PickemGroupMember[]
+
+  @@index([ownerID], map: "PickemGroup_ownerID_fkey")
+  @@index([season], map: "PickemGroup_season_idx")
+}
+
+model PickemGroupMember {
+  id      Int         @id @unique @default(autoincrement())
+  groupID Int
+  userID  String
+  Group   PickemGroup @relation(fields: [groupID], references: [id], onDelete: Cascade)
+  Player  User        @relation("UserPickemGroupMemberships", fields: [userID], references: [id], onDelete: Cascade)
+
+  @@unique([groupID, userID])
+  @@index([groupID], map: "PickemGroupMember_groupID_fkey")
+  @@index([userID], map: "PickemGroupMember_userID_fkey")
+}
+
+model Transaction {
+  id        Int             @id @unique @default(autoincrement())
+  type      TransactionType
+  season    Int
+  date      DateTime        @default(now())
+  userID    String?
+  team      Int?
+  franchise Int?
+  tier      Tier?
+  details   String?         @db.Text // type-specific payload (JSON or human-readable)
+  Player    User?           @relation("PlayerTransactions", fields: [userID], references: [id])
+  Team      Teams?          @relation("TeamTransactions", fields: [team], references: [id])
+  Franchise Franchise?      @relation("FranchiseTransactions", fields: [franchise], references: [id])
+
+  @@index([userID], map: "Transaction_userID_fkey")
+  @@index([team], map: "Transaction_team_fkey")
+  @@index([franchise], map: "Transaction_franchise_fkey")
+  @@index([season], map: "Transaction_season_idx")
 }
 
 enum Tier {
@@ -419,6 +504,24 @@ enum ModLogType {
 enum MapBansSide {
   ATTACK
   DEFENSE
+}
+
+enum TransactionType {
+  ACTIVATE
+  CAPTAIN
+  CUT
+  EXPIRE
+  IR
+  REBRAND
+  RENEW
+  RESCHEDULE
+  RETIRE
+  SCHEDULE_PLAYOFF
+  SIGN
+  SUB
+  TRADE
+  UNSUB
+  UPDATE_TIER
 }
 
 //TODO: Adding this comment to test workflow.  This can be deleted.


### PR DESCRIPTION
## Summary
Adds the Pickem feature tables, a Transaction history table with its data-layer logging method, and a season-default bump.

- New tables:
  - `PickemMatchPick`, `PickemAdvancePick` - a user's per-match and advancement predictions (FKs to `User`, `Matches`, `Teams`)
  - `PickemGroup`, `PickemGroupMember` - pickem groups and their membership (FKs to `User`)
  - `Transaction` - roster/franchise transaction history, with the `TransactionType` enum (FKs to `User`, `Teams`, `Franchise`)
- `_Transaction.ts`: added `Transaction.log({ type, userID?, teamID?, franchiseID?, tier?, details? })` - resolves the current season internally and records a row in the `Transaction` table. Implements the contract that `vdc-bot` PR #368 already calls best-effort (it no-ops until this ships). see https://github.com/Valorant-Draft-Circuit/vdc-bot/pull/368
- Added `ACTIVATE` and `REBRAND` to the `TransactionType` enum.
- Added `PICKEM_ADVANCE_LOCK`, `PICKEM_PREVIEW`, and `PICKEM_ENABLED` control-panel settings.
- Bumped season defaults from 9 to 10 on `Matches`, `Games`, and `ModLogs`.

Migration `20260630194143_v6_0_0` creates the five tables with their foreign keys and alters the three season defaults. Dev was cleaned of out-of-band copies of these tables beforehand, so `migrate deploy` recreates them cleanly.

## DB
- [x] Migrations included (if schema changed)

## Release
Release Version (optional): v6.0.0
<!-- Example: v1.9.0  (must be > last tag). Leave blank to auto-bump. -->