### PR TITLE
fix connection pooling issue

### DIFF
--- a/_Transaction.ts
+++ b/_Transaction.ts
@@ -1,8 +1,6 @@
-import { ContractStatus, LeagueStatus, PrismaClient, Tier, TransactionType } from '@prisma/client';
-import { Player } from './_Player';
+import { ContractStatus, LeagueStatus, Tier, TransactionType } from '@prisma/client';
+import { prisma } from './prismadb';
 import { ControlPanel } from './_ControlPanel';
-
-const prisma = new PrismaClient();
 
 export class Transaction {
     static async updateStatus(

--- a/prismadb.js
+++ b/prismadb.js
@@ -1,6 +1,12 @@
 const { PrismaClient } = require(`@prisma/client`);
-const prisma = new PrismaClient();
+
+const globalForPrisma = globalThis;
+const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== `production`) {
+  globalForPrisma.prisma = prisma;
+}
 
 module.exports = {
-    prisma: prisma,
+  prisma: prisma,
 };


### PR DESCRIPTION
## Summary
Fixes database connection-pool exhaustion caused by multiple `PrismaClient` instances.

Every `new PrismaClient()` opens its own connection pool. The app was instantiating clients in more than one place. a global one in `prismadb.js` plus a separate one inside `_Transaction.ts`, and in non-production the client was re-created on every module re-evaluation/hot-reload. Under load this exhausted the available database connections.

Changes:
- `prismadb.js`: use a single global Prisma singleton (`globalThis.prisma`), reusing the existing instance instead of creating a new one, and cache it on `globalThis` outside of production to survive hot-reloads.
- `_Transaction.ts`: remove the local `new PrismaClient()` and import the shared `prisma` client from `./prismadb`.

Net effect: exactly one `PrismaClient` (one connection pool) per process.

## DB
- [ ] Migrations included (if schema changed) — N/A, no schema changes

## Release
Release Version (optional): v6.0.1
<!-- Leave blank to auto-bump — this is a patch-level fix -->