### PR TITLE
moderation tool additions

### DIFF
--- a/_ModLogs.ts
+++ b/_ModLogs.ts
@@ -1,0 +1,76 @@
+import { ModLogType } from "@prisma/client";
+import { prisma } from "./prismadb";
+
+/** Rows older than this never drive bot enforcement (mute cache, rejoin
+ * re-mute, reconciliation, lift guards). Legacy Dyno-era records commonly
+ * have NULL expires, which would otherwise read as active permanent
+ * sanctions. They remain visible as dashboard/history data. */
+export const MOD_TOOLS_EPOCH = new Date("2026-07-03T00:00:00Z");
+
+export class ModLogs {
+  static async create(options: {
+    discordID: string;
+    modID: string;
+    type: ModLogType;
+    message: string;
+    expires?: Date | null;
+  }) {
+    const { discordID, modID, type, message, expires } = options;
+    return await prisma.modLogs.create({
+      data: { discordID, modID, type, message, expires: expires ?? null },
+    });
+  }
+
+  static async historyFor(discordID: string) {
+    return await prisma.modLogs.findMany({
+      where: { discordID },
+      orderBy: { date: `desc` },
+    });
+  }
+
+  static async activeSanctions(type: ModLogType) {
+    return await prisma.modLogs.findMany({
+      where: {
+        type,
+        date: { gte: MOD_TOOLS_EPOCH },
+        OR: [{ expires: null }, { expires: { gt: new Date() } }],
+      },
+    });
+  }
+
+  static async activeSanctionsFor(discordID: string, type: ModLogType) {
+    return await prisma.modLogs.findMany({
+      where: {
+        discordID,
+        type,
+        date: { gte: MOD_TOOLS_EPOCH },
+        OR: [{ expires: null }, { expires: { gt: new Date() } }],
+      },
+    });
+  }
+
+  static async everSanctioned(type: ModLogType) {
+    const rows = await prisma.modLogs.findMany({
+      where: { type, date: { gte: MOD_TOOLS_EPOCH } },
+      select: { discordID: true },
+      distinct: [`discordID`],
+    });
+    return rows.map((r) => r.discordID);
+  }
+
+  static async liftSanctions(options: {
+    discordID: string;
+    type: ModLogType;
+    appealNote: string;
+  }) {
+    const { discordID, type, appealNote } = options;
+    const activeRows = await ModLogs.activeSanctionsFor(discordID, type);
+    for (const row of activeRows) {
+      await prisma.modLogs.update({
+        where: { id: row.id },
+        data: { expires: new Date(), message: `${row.message}\n${appealNote}` },
+      });
+    }
+    return activeRows.length;
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -4,5 +4,6 @@ export { Player } from "./_Player";
 export { Transaction } from "./_Transaction";
 export { Team } from "./_Team";
 export { ControlPanel } from "./_ControlPanel";
+export { ModLogs, MOD_TOOLS_EPOCH } from "./_ModLogs";
 
 export { Flags, Roles } from "./enums"

--- a/migrations/20260703000000_v6_1_0_drop_modlogs_discordid_fk/migration.sql
+++ b/migrations/20260703000000_v6_1_0_drop_modlogs_discordid_fk/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE `ModLogs` DROP FOREIGN KEY `ModLogs_discordID_fkey`;
+
+-- RenameIndex
+ALTER TABLE `ModLogs` RENAME INDEX `ModLogs_discordID_fkey` TO `ModLogs_discordID_idx`;

--- a/schema.prisma
+++ b/schema.prisma
@@ -8,24 +8,23 @@ datasource db {
 }
 
 model Account {
-  id                String    @id @unique @default(cuid())
+  id                String  @id @unique @default(cuid())
   userId            String
   type              String
   provider          String
-  providerAccountId String    @unique
+  providerAccountId String  @unique
   refresh_token     String?
-  access_token      String?   @db.Text
+  access_token      String? @db.Text
   expires_at        Int?
   token_type        String?
   scope             String?
   id_token          String?
   session_state     String?
   riotIGN           String?
-  mmr               Int?      @unique
-  MMR               MMR?      @relation("MMR", fields: [mmr], references: [id], onDelete: Cascade)
-  User              User      @relation("Accounts", fields: [userId], references: [id], onDelete: Cascade)
-  ModLogs           ModLogs[] @relation("ModLogs")
-  UserAccount       User?     @relation("PrimaryRiotAccount")
+  mmr               Int?    @unique
+  MMR               MMR?    @relation("MMR", fields: [mmr], references: [id], onDelete: Cascade)
+  User              User    @relation("Accounts", fields: [userId], references: [id], onDelete: Cascade)
+  UserAccount       User?   @relation("PrimaryRiotAccount")
 
   @@index([userId], map: "Account_userId_fkey")
 }
@@ -333,10 +332,9 @@ model ModLogs {
   type      ModLogType
   message   String     @db.Text
   expires   DateTime?
-  Player    Account    @relation("ModLogs", fields: [discordID], references: [providerAccountId])
   Moderator User       @relation("ModHistory", fields: [modID], references: [id])
 
-  @@index([discordID], map: "ModLogs_discordID_fkey")
+  @@index([discordID], map: "ModLogs_discordID_idx")
   @@index([modID], map: "ModLogs_modID_fkey")
 }
 


### PR DESCRIPTION
## Summary
- added `_ModLogs.ts`, controller exposing `create`, `historyFor`, `activeSanctions` / `activeSanctionsFor`, `everSanctioned`, and `liftSanctions`; exported from `index.ts`
- added `MOD_TOOLS_EPOCH` (2026-07-03) so legacy/imported rows (often with NULL `expires`) stay visible as history/dashboard data but never drive bot enforcement (mute cache, rejoin re-mute, lift guards)
- `liftSanctions` expires a user's active sanctions of a type now and appends the appeal note to each message; returns the count lifted
- schema: dropped the `ModLogs.discordID → Account.providerAccountId` foreign key (removed the `Player` relation and the `Account.ModLogs` back-relation), replacing the FK index with a plain `ModLogs_discordID_idx`, so a log can reference a Discord ID that has no VDC `Account` (legacy / migrated users); plus whitespace realignment in the `Account` model

## DB
- [x] Migrations included (if schema changed)

## Release
Release Version (optional): v6.1.0