### PR TITLE
Yuls/modlogs

### DIFF
--- a/_ModLogs.ts
+++ b/_ModLogs.ts
@@ -15,8 +15,10 @@ export class ModLogs {
     message: string;
     expires?: Date | null;
     season?: number;
+    details?: object | null;
   }) {
-    const { discordID, modID, type, message, expires, season } = options;
+    const { discordID, modID, type, message, expires, season, details } =
+      options;
     return await prisma.modLogs.create({
       data: {
         discordID,
@@ -24,6 +26,7 @@ export class ModLogs {
         type,
         message,
         expires: expires ?? null,
+        details: details ? JSON.stringify(details) : null,
         ...(season !== undefined ? { season } : {}),
       },
     });
@@ -92,6 +95,27 @@ export class ModLogs {
         date: { gte: MOD_TOOLS_EPOCH },
         OR: [{ expires: null }, { expires: { gt: new Date() } }],
       },
+    });
+  }
+
+  /** All MAP_BAN rows for a player since the mod-tools epoch, oldest first.
+   * "Active" cannot be a where-clause: remaining maps are derived from played
+   * games, so callers compute remaining per row (src/helpers/mod/mapBans.js). */
+  static async mapBansFor(discordID: string) {
+    return await prisma.modLogs.findMany({
+      where: {
+        discordID,
+        type: ModLogType.MAP_BAN,
+        date: { gte: MOD_TOOLS_EPOCH },
+      },
+      orderBy: { date: `asc` },
+    });
+  }
+
+  static async updateDetails(id: number, details: object) {
+    return await prisma.modLogs.update({
+      where: { id },
+      data: { details: JSON.stringify(details) },
     });
   }
 

--- a/_Transaction.ts
+++ b/_Transaction.ts
@@ -135,6 +135,36 @@ export class Transaction {
         });
     };
 
+    /** Mark the player a substitute replaced as SUBBED_OUT so vdc-web can pair them.
+     * Only transitions from SIGNED so an IR (or otherwise changed) status is never overwritten. */
+    static async markSubbedOut(userID: string) {
+        return await prisma.status.updateMany({
+            where: { userID: userID, contractStatus: ContractStatus.SIGNED },
+            data: { contractStatus: ContractStatus.SUBBED_OUT }
+        });
+    };
+
+    /** Restore a replaced player to SIGNED when their substitute's stint ends.
+     * Only transitions from SUBBED_OUT so an admin-changed status is never overwritten. */
+    static async restoreSubbedOut(userID: string) {
+        return await prisma.status.updateMany({
+            where: { userID: userID, contractStatus: ContractStatus.SUBBED_OUT },
+            data: { contractStatus: ContractStatus.SIGNED }
+        });
+    };
+
+    /** Get the most recent SUB transaction for a sub on a team (its details carry the pairing) */
+    static async getLatestSub(options: { userID: string, teamID: number }) {
+        return await prisma.transaction.findFirst({
+            where: {
+                type: TransactionType.SUB,
+                userID: options.userID,
+                team: options.teamID
+            },
+            orderBy: { id: `desc` }
+        });
+    };
+    
     /** Unsub a player for a team */
     static async unsub(userID: string) {
         return await prisma.user.update({

--- a/migrations/20260714120000_v6_3_0/migration.sql
+++ b/migrations/20260714120000_v6_3_0/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE `ModLogs` ADD COLUMN `details` TEXT NULL;
+
+-- AlterEnum
+ALTER TABLE `ModLogs` MODIFY `type` ENUM('NOTE', 'INFORMAL_WARNING', 'FORMAL_WARNING', 'MUTE', 'BAN', 'MAP_BAN') NOT NULL;

--- a/schema.prisma
+++ b/schema.prisma
@@ -333,6 +333,7 @@ model ModLogs {
   date      DateTime   @default(now())
   type      ModLogType
   message   String     @db.Text
+  details   String?    @db.Text // type-specific payload (JSON), mirrors Transaction.details
   expires   DateTime?
   Moderator User       @relation("ModHistory", fields: [modID], references: [id])
 
@@ -398,10 +399,10 @@ model PickemBracketPick {
   userID              String
   season              Int
   tier                Tier
-  round               Int 
-  slot                Int 
+  round               Int
+  slot                Int
   predictedTeam       Int
-  predictedLoserGames Int 
+  predictedLoserGames Int
   Player              User   @relation("UserPickemBracketPicks", fields: [userID], references: [id], onDelete: Cascade)
   Team                Teams  @relation("PickemBracketPicks", fields: [predictedTeam], references: [id])
 
@@ -517,6 +518,7 @@ enum ModLogType {
   FORMAL_WARNING
   MUTE
   BAN
+  MAP_BAN
 }
 
 enum MapBansSide {


### PR DESCRIPTION
## Summary
Adds mod-log support for **map-ban** and **sub/unsub** moderation commands.

- **Schema** (`ModLogs`): new nullable `details String? @db.Text` column for a type-specific JSON payload (mirrors `Transaction.details`), and new `MAP_BAN` value on the `ModLogType` enum.
- **`_ModLogs.ts`**: `create()` now accepts an optional `details` object (JSON-stringified into the column); adds `mapBansFor(discordID)` (all `MAP_BAN` rows since the mod-tools epoch, oldest first) and `updateDetails(id, details)`.
- **`_Transaction.ts`**: adds `markSubbedOut(userID)` (SIGNED → SUBBED_OUT) and `restoreSubbedOut(userID)` (SUBBED_OUT → SIGNED), each guarded to only transition from the expected status, plus `getLatestSub({userID, teamID})` to fetch the SUB transaction whose `details` carry the pairing.

## DB
- [x] Migrations included (if schema changed)
  - `migrations/20260714120000_v6_3_0/migration.sql`: adds the `details` column and the `MAP_BAN` enum value. Both changes are additive (nullable column, appended enum value), so no backfill or data loss.

## Release
Release Version (optional): v6.3.0
<!-- Example: v1.9.0  (must be > last tag). Leave blank to auto-bump. -->
<!-- Last tag is v6.2.0; additive change, minor bump. Matches the v6_3_0 migration. -->